### PR TITLE
Acer Nitro 16-42 and quirk for AN16 series 

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -436,7 +436,10 @@ static struct quirk_entry quirk_acer_predator_phn16_71 = {
 static struct quirk_entry quirk_acer_nitro = {
 	.nitro_sense = 1,
 };
-
+static struct quirk_entry quirk_acer_nitro_an16_series = {
+	.nitro_sense = 1,
+	.four_zone_kb=1
+};
 static struct quirk_entry quirk_acer_predator_v4 = {
 	.predator_v4 = 1,
 };
@@ -500,6 +503,15 @@ static const struct dmi_system_id amw0_whitelist[] __initconst = {
  * that those machines are supported by acer-wmi driver.
  */
 static const struct dmi_system_id acer_quirks[] __initconst = {
+	{
+		.callback = dmi_matched,
+		.ident = "Acer Nitro AN16-42",
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN16-42"),
+		},
+		.driver_data = &quirk_acer_nitro_an16_series,
+	},
 	{
 		.callback = dmi_matched,
 		.ident = "Acer Nitro ANV15-41",

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -436,10 +436,13 @@ static struct quirk_entry quirk_acer_predator_phn16_71 = {
 static struct quirk_entry quirk_acer_nitro = {
 	.nitro_sense = 1,
 };
+
+/*All notebooks of the AN16 series come with a four zone rgb keyboard*/
 static struct quirk_entry quirk_acer_nitro_an16_series = {
 	.nitro_sense = 1,
 	.four_zone_kb=1
 };
+
 static struct quirk_entry quirk_acer_predator_v4 = {
 	.predator_v4 = 1,
 };


### PR DESCRIPTION
- I whitelisted the Acer Nitro 16-42. 
- I added a quirk for the AN16 series. All models of this series contain a four zone rgb keyboard.
- Backlight Timeout, Battery Limiter and Fan Speed are tested and working