### PR TITLE
Nitro v4 quirk, support for AN16-41, 16-43, uninstall tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ uninstall:
 		echo "Group linuwu_sense does not exist."; \
 	fi
 	@sudo rm -f /etc/tmpfiles.d/$(MODNAME).conf
+	@sudo rm -f $(MDIR)/$(MODNAME).ko
+	@sudo depmod -a
 	@echo "Uninstalled $(MODNAME) and cleaned up related configuration."
 
 install: all

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -485,6 +485,11 @@ enum acer_wmi_predator_v4_oc {
     .four_zone_kb = 1,
  };
 
+  static struct quirk_entry quirk_acer_nitro_an16_43 = {
+    .nitro_v4 = 1,
+    .four_zone_kb = 1,
+ };
+
  static struct quirk_entry quirk_acer_nitro = {
      .nitro_sense = 1,
  };
@@ -556,6 +561,15 @@ enum acer_wmi_predator_v4_oc {
   * that those machines are supported by acer-wmi driver.
   */
  static const struct dmi_system_id acer_quirks[] __initconst = {
+     {
+         .callback = dmi_matched,
+         .ident = "Acer Nitro AN16-43",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN16-43"),
+         },
+         .driver_data = &quirk_acer_nitro_an16_43,
+     },
      {
          .callback = dmi_matched,
          .ident = "Acer Nitro AN16-41",

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -2612,9 +2612,9 @@ enum acer_wmi_predator_v4_oc {
          break;
      case WMID_GAMING_TURBO_KEY_EVENT:
         pr_info("pressed turbo button - %d\n", return_value.key_num);
-         if (return_value.key_num == 0x4)
+         if (return_value.key_num == 0x4  && !has_cap(ACER_CAP_NITRO_SENSE_V4))
              acer_toggle_turbo();
-         if (return_value.key_num == 0x5 && has_cap(ACER_CAP_PLATFORM_PROFILE))
+         if ((return_value.key_num == 0x5 || (return_value.key_num == 0x4 && has_cap(ACER_CAP_NITRO_SENSE_V4))) && has_cap(ACER_CAP_PLATFORM_PROFILE))
              acer_thermal_profile_change();
          break;
      case WMID_AC_EVENT:

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -470,6 +470,11 @@ enum acer_wmi_predator_v4_oc {
     .four_zone_kb = 1,
  };
  
+ static struct quirk_entry quirk_acer_nitro_an16_41 = {
+    .predator_v4 = 1,
+    .four_zone_kb = 1,
+ };
+
  static struct quirk_entry quirk_acer_nitro = {
      .nitro_sense = 1,
  };
@@ -537,6 +542,15 @@ enum acer_wmi_predator_v4_oc {
   * that those machines are supported by acer-wmi driver.
   */
  static const struct dmi_system_id acer_quirks[] __initconst = {
+     {
+         .callback = dmi_matched,
+         .ident = "Acer Nitro AN16-41",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN16-41"),
+         },
+         .driver_data = &quirk_acer_nitro_an16_41,
+     },
      {
          .callback = dmi_matched,
          .ident = "Acer Nitro ANV15-41",


### PR DESCRIPTION
`nitro_v4` quirk makes sure that laptops with Nitro Sense v4 need not use the `predator_v4` quirk and end up with a predator_sense folder. Also remaps the key for mode cycling to 0x4.

Added support for Acer Nitro 16 AN16-41 which uses `nitro_v4` quirk. 
**Tested and verified**
- [x] 4-zone keyboard
- [x] Battery limiter 
- [x] Backlight timeout 
- [x] Battery calibration
- [x] LCD Override (not sure how to test if it's working)
- [x] Fan control
- [x] USB Charging

~**NOTE**: Mode switcher button isn't changing the mode although changing it through the terminal works. I'm looking into this problem.~

EDIT: Updated keycode of mode switching in Nitro v4 laptops to 0x4. 

Tested on AC
- [x] Quiet
- [x] Balanced
- [x] Performance
- [x] Turbo

Power disconnected
- [x] Eco
- [x] Balanced 

Closes #20 