### PR TITLE
Add support for Acer nitro AN515-58 (2022)

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -3547,10 +3547,12 @@ enum acer_wmi_predator_v4_oc {
  };
  /* nitro sense attributes */
  static struct attribute *nitro_sense_attrs[] = {
+     &lcd_override.attr,
      &fan_speed.attr,
      &battery_limiter.attr,
      &battery_calibration.attr,
      &usb_charging.attr,
+     &backlight_timeout.attr,
      NULL
  }; 
  static struct attribute_group nitro_sense_attr_group = {

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -490,6 +490,11 @@ enum acer_wmi_predator_v4_oc {
     .four_zone_kb = 1,
  };
 
+ static struct quirk_entry quirk_acer_nitro_an515_58 = {
+    .nitro_sense = 1,
+    .four_zone_kb = 1,
+ };
+
  static struct quirk_entry quirk_acer_nitro = {
      .nitro_sense = 1,
  };
@@ -569,6 +574,15 @@ enum acer_wmi_predator_v4_oc {
              DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN16-43"),
          },
          .driver_data = &quirk_acer_nitro_an16_43,
+     },
+     {
+         .callback = dmi_matched,
+         .ident = "Acer Nitro AN515-58",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN515-58"),
+         },
+         .driver_data = &quirk_acer_nitro_an515_58,
      },
      {
          .callback = dmi_matched,


### PR DESCRIPTION
This fixes issue #25


A. Testings

1. Fans: works perfectly (manual & auto mode)
2. Keyboard led: Works (4 Zone color switching)
3. Thermal profiles: Works switching between quite/balanced/balanced-performance (tested with `stress --cpu 1000` & co-related with fan speeds)
4. Battery Calibration: works
5. Battery Limiter: works
6. LCD Override: works

** PS: some older nitrosense also support lcd override & keyboard backlight, so added them also