### PR TITLE
Added support for Acer Nitro ANV16-71

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -498,6 +498,14 @@ enum acer_wmi_predator_v4_oc {
     .four_zone_kb = 1,
  };
  
+static struct quirk_entry quirk_acer_nitro_anv16_71 = {
+    .nitro_v4 = 1,
+    .cpu_fans = 1,
+    .gpu_fans = 1,
+    .brightness = 1,
+    .turbo = 1,         
+};
+ 
  static struct quirk_entry quirk_acer_nitro_an515_58 = {
     .nitro_v4 = 1,
     .four_zone_kb = 1,
@@ -611,6 +619,15 @@ enum acer_wmi_predator_v4_oc {
          },
          .driver_data = &quirk_acer_nitro_anv16_41,
      },
+     {
+        .callback = dmi_matched,
+        .ident = "Acer Nitro ANV16-71",
+        .matches = {
+            DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+            DMI_MATCH(DMI_PRODUCT_NAME, "Nitro ANV16-71"),
+        },
+        .driver_data = &quirk_acer_nitro_anv16_71,
+    },
      {
          .callback = dmi_matched,
          .ident = "Acer Nitro ANV15-41",


### PR DESCRIPTION
**Summary:**
 This PR adds and improves support for the Nitro ANV16-71 in Linuwu-Sense.

**Working features:**
 Performance profiles (thermal/CPU/GPU modes)
 Dashboard integration
 Automatic model detection on boot
 CPU/GPU fan controls
 Battery limits (smart charging)

**Features that need testing:**
 Backlight timeout
 Battery calibration
 USB Power Delivery

**Notes:**
 Module builds and loads successfully.
 Secure Boot users must sign the module after recompilation.
 Feedback on the untested features is appreciated to ensure full functionality.