### PR TITLE
Add Nitro ANV16S-41 Support

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -492,6 +492,11 @@ enum acer_wmi_predator_v4_oc {
     .nitro_v4 = 1,
     .four_zone_kb = 0,
  };
+ 
+ static struct quirk_entry quirk_acer_nitro_anv16s_41 = {
+    .nitro_v4 = 1,
+    .four_zone_kb = 1,
+ };
 
   static struct quirk_entry quirk_acer_nitro_an16_43 = {
     .nitro_v4 = 1,
@@ -509,6 +514,10 @@ enum acer_wmi_predator_v4_oc {
  };
  
  static struct quirk_entry quirk_acer_predator_v4 = {
+     .predator_v4 = 1,
+ };
+
+ static struct quirk_entry quirk_acer_nitro_anv4 = {
      .predator_v4 = 1,
  };
  
@@ -610,6 +619,15 @@ enum acer_wmi_predator_v4_oc {
              DMI_MATCH(DMI_PRODUCT_NAME, "Nitro ANV16-41"),
          },
          .driver_data = &quirk_acer_nitro_anv16_41,
+     },
+          {
+         .callback = dmi_matched,
+         .ident = "Acer Nitro ANV16S-41",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Nitro ANV16S-41"),
+         },
+         .driver_data = &quirk_acer_nitro_anv16s_41,
      },
      {
          .callback = dmi_matched,


### PR DESCRIPTION
I have tested adding support for this locally, but it is not recognizing the drivers and changes are not applied when trying to set different colors  or patterns to the keyboard, only works to disable the timeout for keyboard turning off.


```
$ sudo make install
make -C /lib/modules/6.17.9-200.nobara.fc43.x86_64/build M=/home/deblintrake/Linuwu-Sense modules
make[1]: se entra en el directorio '/usr/src/kernels/6.17.9-200.nobara.fc43.x86_64'
make[2]: se entra en el directorio '/home/deblintrake/Linuwu-Sense'
  CC [M]  src/linuwu_sense.o
src/linuwu_sense.c:520:28: aviso: se define ‘quirk_acer_nitro_anv4’ pero no se usa [-Wunused-variable]
  520 |  static struct quirk_entry quirk_acer_nitro_anv4 = {
      |                            ^~~~~~~~~~~~~~~~~~~~~
  MODPOST Module.symvers
  CC [M]  src/linuwu_sense.mod.o
  LD [M]  src/linuwu_sense.ko
  BTF [M] src/linuwu_sense.ko
Skipping BTF generation for src/linuwu_sense.ko due to unavailability of vmlinux
make[2]: se sale del directorio '/home/deblintrake/Linuwu-Sense'
make[1]: se sale del directorio '/usr/src/kernels/6.17.9-200.nobara.fc43.x86_64'
sudo install -d /lib/modules/6.17.9-200.nobara.fc43.x86_64/kernel/drivers/platform/x86
sudo install -m 644 src/linuwu_sense.ko /lib/modules/6.17.9-200.nobara.fc43.x86_64/kernel/drivers/platform/x86
sudo depmod -a
sudo modprobe linuwu_sense
Setting up group and permissions...
Detected user: deblintrake
sudo usermod -aG linuwu_sense deblintrake
Setting permissions via tmpfiles...
Warning: Could not detect predator_sense or nitro_sense in sysfs.
Module linuwu_sense installed and configured to load at boot.
```

The GUI on DAMX for example shows that it is reconized as a NITRO and model, but does not recognize the drivers.

<img width="1067" height="350" alt="Image" src="https://github.com/user-attachments/assets/4d8107e5-a8bc-4d63-ba62-f969099b77ca" />
