### PR TITLE
Sign issue fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,26 @@ REAL_USER := $(shell echo $${SUDO_USER:-$$(whoami)})
 all:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
+	# --- auto sign block ---
+	
+	#finding sign-file tool
+	if [ -x "/lib/modules/$(KVER)/build/scripts/sign-file" ]; then \
+		SIGN_TOOL="/lib/modules/$(KVER)/build/scripts/sign-file"; \
+	elif [ -x "/usr/src/linux-headers-$(KVER)/scripts/sign-file" ]; then \
+		SIGN_TOOL="/usr/src/linux-headers-$(KVER)/scripts/sign-file"; \
+	else \
+		echo "ERROR: sign-file tool not found"; \
+		exit 1; \
+	fi; \
+
+	# assuming keys are located in a ~/module-signing folder named MOK....
+	echo "Signing module linuwu_sense.ko using $$SIGN_TOOL"; \
+	sudo $$SIGN_TOOL sha256 \
+		$(HOME)/module-signing/MOK.priv \  
+		$(HOME)/module-signing/MOK.der \
+		$(PWD)/src/linuwu_sense.ko
+	# --- end auto sign block ---
+
 clean:
 	$(MAKE) -C $(KDIR) M=$(PWD) clean
 
@@ -43,6 +63,7 @@ install: all
 	sudo depmod -a
 	@echo "$(MODNAME)" | sudo tee /etc/modules-load.d/$(MODNAME).conf > /dev/null
 	sudo modprobe $(MODNAME)
+	@sleep 2
 	@sudo cp linuwu_sense.service /etc/systemd/system/
 	@sudo systemctl daemon-reload
 	@sudo systemctl enable linuwu_sense.service

--- a/module_signing_readme
+++ b/module_signing_readme
@@ -1,0 +1,27 @@
+1. Create a folder to store the keys
+
+# creates folder in home/userName/ directory
+mkdir -p ~/module-signing
+cd ~/module-signing
+
+2. Generate the keys
+
+openssl req -new -x509 -newkey rsa:2048 -keyout MOK.priv -outform DER -out MOK.der \
+    -nodes -days 36500 -subj "/CN=LinuwuKey/"
+
+3. Makefile usage
+....
+
+4. Enroll the key
+
+sudo mokutil --import ~/module-signing/MOK.der
+
+# setup a temp password
+# reboot
+# select enroll mok
+# select key 0
+# select enroll
+
+
+# The steps 3 and 4 can be interchangeable, BUT make sure the module is SIGNED before it is loaded, which is
+# carried out in step 3 anyways during Makefile usage.


### PR DESCRIPTION
Hello, 

I recently discovered Linuwu-Sense Drivers and their usage in the DAMX application by [Div-Acer-Manager-Max](https://github.com/PXDiv/Div-Acer-Manager-Max). The first time I tried to install it I ran into driver signing issues, so I had to figure out how to fix it.

I realized I cannot use Secure Boot while I use this, if I do I have to sign my drivers, but I also need Secure Boot since I dual boot windows as well and "Vanguard" of "Valorant" requires Secure Boot.

So, I figured out how to fix it, but the process was tedious if I lost the track of where I was so, next time I updated my nvidia drivers, or the kernel got updated, I had to reinstall and resign the driver.

It was a mess, what I'm writing right now also doesn't make any sense, but it works, I've tried it 3-4 times now, new installation, driver update, and with kernel upgrade/downgrade.

This can be just for observational purposes as well, maybe you'll get the idea of what I was facing and develop a better solution because right now what the part of "auto-sign" portion does is just look for sign-file tool, assume keys are location at a certain location "module-signing" and then before the driver is installed, the driver is signed manually.

Other steps are given in the readme file which are must to follow.

I hope you find this useful to in some way. Please forgive me if I'm doing something wrong, this is my first Pull Request.

Thank you for your great work, cheers.