### PR TITLE
Add support for Acer Predator Triton 17X (PTX17-71)

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -792,6 +792,15 @@ enum acer_wmi_predator_v4_oc {
          .driver_data = &quirk_acer_predator_v4,
      },
      {
+         .callback = dmi_matched,
+         .ident = "Acer Predator PTX17-71",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Predator PTX17-71"),
+         },
+         .driver_data = &quirk_acer_predator_v4,
+     },
+     {
          .callback = set_force_caps,
          .ident = "Acer Aspire Switch 10E SW3-016",
          .matches = {


### PR DESCRIPTION
## Summary

Adds DMI match entry for the **Acer Predator Triton 17X (PTX17-71)** to the Predator v4 quirk table.

## Changes

- Added DMI entry matching `Acer` / `Predator PTX17-71` using `quirk_acer_predator_v4`

## DMI Strings

```
SYS_VENDOR:    Acer
PRODUCT_NAME:  Predator PTX17-71
```

## Testing

- Tested on Acer Predator Triton 17X PTX17-71, Pop!_OS 24.04, kernel 6.18.7
- Initially confirmed working with `predator_v4=1` module parameter (force-enable)
- With this DMI entry, the model is detected automatically without the force parameter
- Fan speed control via `/sys/module/linuwu_sense/drivers/platform:acer-wmi/acer-wmi/predator_sense/fan_speed` confirmed working (both CPU and GPU fan control)
- Platform profile switching functional

## Notes

- The `platform_profile_ops` API change for kernel 6.17+ is handled separately in PR #73