### PR TITLE
fix: make module signing optional and fix variable scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,23 +12,24 @@ all:
 	$(MAKE) -C $(KDIR) M=$(PWD) modules
 
 	# --- auto sign block ---
-	
-	#finding sign-file tool
+	# Check if keys exist before attempting to sign
+	@if [ -f "$(HOME)/module-signing/MOK.priv" ] && [ -f "$(HOME)/module-signing/MOK.der" ]; then \
 	if [ -x "/lib/modules/$(KVER)/build/scripts/sign-file" ]; then \
-		SIGN_TOOL="/lib/modules/$(KVER)/build/scripts/sign-file"; \
+	SIGN_TOOL="/lib/modules/$(KVER)/build/scripts/sign-file"; \
 	elif [ -x "/usr/src/linux-headers-$(KVER)/scripts/sign-file" ]; then \
-		SIGN_TOOL="/usr/src/linux-headers-$(KVER)/scripts/sign-file"; \
+	SIGN_TOOL="/usr/src/linux-headers-$(KVER)/scripts/sign-file"; \
 	else \
-		echo "ERROR: sign-file tool not found"; \
-		exit 1; \
+	echo "ERROR: sign-file tool not found, but MOK keys exist."; \
+	exit 1; \
 	fi; \
-
-	# assuming keys are located in a ~/module-signing folder named MOK....
 	echo "Signing module linuwu_sense.ko using $$SIGN_TOOL"; \
 	sudo $$SIGN_TOOL sha256 \
-		$(HOME)/module-signing/MOK.priv \  
-		$(HOME)/module-signing/MOK.der \
-		$(PWD)/src/linuwu_sense.ko
+	$(HOME)/module-signing/MOK.priv \
+	$(HOME)/module-signing/MOK.der \
+	$(PWD)/src/linuwu_sense.ko; \
+	else \
+	echo "MOK keys not found in ~/module-signing/. Skipping module signing (Common for non-Secure Boot)."; \
+	fi
 	# --- end auto sign block ---
 
 clean:


### PR DESCRIPTION
### What does this PR do?
This PR fixes an issue where `make install` fails with a `sudo: sha256: command not found` error on systems that do not have Secure Boot keys configured or are missing the kernel headers. 

### Why is this needed?
1. **Variable Scope Fix:** In the original `all:` target, `SIGN_TOOL` was being set in one sub-shell and executed in another. If the tool wasn't found, the variable was empty, causing the script to mistakenly run `sudo sha256`. I chained the shell execution using `\` and `;` so the variables persist correctly.
2. **Optional Signing:** The previous logic forced a module signing attempt regardless of whether the user had Secure Boot enabled or MOK keys generated. This PR wraps the signing block in a condition that checks for the existence of `MOK.priv` and `MOK.der`. 

### Behavior Changes:
* **With MOK keys:** Behaves exactly as before, signing the module automatically.
* **Without MOK keys:** Gracefully skips the signing process and proceeds with the installation, printing a helpful info message.

### Testing:
Tested on an Acer Predator Helios 16 (PH16-71) running Arch Linux (Kernel 6.19). `make install` now successfully completes without requiring a manual workaround.

**Resolves #89 ** 