### PR TITLE
Add Acer Nitro AN515-45 support and enable four-zone keyboard

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -517,6 +517,11 @@ enum acer_wmi_predator_v4_oc {
     .four_zone_kb = 1,
  };
 
+static struct quirk_entry quirk_acer_nitro_an515_45 = {
+    .nitro_v4 = 1,
+    .four_zone_kb = 1,
+};
+
 
  static struct quirk_entry quirk_acer_nitro = {
      .nitro_sense = 1,
@@ -668,7 +673,7 @@ enum acer_wmi_predator_v4_oc {
              DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
              DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN515-45"),
          },
-         .driver_data = &quirk_acer_nitro_legacy,
+         .driver_data = &quirk_acer_nitro_an515_45,
      },
      {
          .callback = dmi_matched,

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -663,6 +663,15 @@ enum acer_wmi_predator_v4_oc {
      },
      {
          .callback = dmi_matched,
+         .ident = "Acer Nitro AN515-45",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Nitro AN515-45"),
+         },
+         .driver_data = &quirk_acer_nitro_legacy,
+     },
+     {
+         .callback = dmi_matched,
          .ident = "Acer Aspire 1360",
          .matches = {
              DMI_MATCH(DMI_SYS_VENDOR, "Acer"),


### PR DESCRIPTION
### **Description**
This PR adds a DMI entry and quirk profile for the **Acer Nitro AN515-45**. While the device was previously detected as a Nitro model, the four-zone RGB keyboard functionality was not being exposed.

**Changes:**
* Added DMI entry for `AN515-45`.
* Created a new quirk profile enabling `nitro_v4` and `four_zone_kb`.
* Improved DAMX detection logic to ensure four-zone keyboard features are correctly identified and exposed.

This enables `four_zone_mode` and `per_zone_mode` sysfs attributes for this specific model.

---

### **Testing Performed**
* **Environment:** Kernel `6.17.0-19-generic`
* **Procedure:** Built and installed the updated module, restarted the daemon, and reloaded the module.
* **Verification:** Confirmed via system logs that the device is correctly identified:
    * `Detected laptop type: NITRO`
    * `Four-zone keyboard: Yes`
* **Functionality:** Verified that `four_zone_mode` and `per_zone_mode` are now visible and functional.