### PR TITLE
added support for PH315-52 and tested it

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -436,9 +436,12 @@ enum acer_wmi_predator_v4_oc {
          }
 
  
-     if (quirks->predator_v4)
-         interface->capability |= ACER_CAP_PLATFORM_PROFILE |
-                      ACER_CAP_FAN_SPEED_READ | ACER_CAP_PREDATOR_SENSE;
+    if (quirks->predator_v4 == 1)
+                interface->capability |= ACER_CAP_PLATFORM_PROFILE |
+                ACER_CAP_FAN_SPEED_READ | ACER_CAP_PREDATOR_SENSE;
+                else if (quirks->predator_v4 == 2)
+                /* PredatorSense v3 firmware: thermal profile WMI methods not implemented */
+                interface->capability |= ACER_CAP_FAN_SPEED_READ | ACER_CAP_PREDATOR_SENSE;
      
      /* Includes all feature that predatorv4 have*/
      if (quirks->nitro_v4)
@@ -472,6 +475,12 @@ enum acer_wmi_predator_v4_oc {
      .mailled = 1,
  };
  
+ static struct quirk_entry quirk_acer_predator_ph315_52 = {
+     .turbo = 1,
+     .predator_v4 = 2,
+     .four_zone_kb = 1,
+ };
+
  static struct quirk_entry quirk_acer_predator_ph315_53 = {
      .turbo = 1,
      .cpu_fans = 1,
@@ -768,6 +777,15 @@ enum acer_wmi_predator_v4_oc {
              DMI_MATCH(DMI_PRODUCT_NAME, "TravelMate 4200"),
          },
          .driver_data = &quirk_acer_travelmate_2490,
+     },
+     {
+         .callback = dmi_matched,
+         .ident = "Acer Predator PH315-52",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_BOARD_NAME, "QX50_CMS"),
+         },
+         .driver_data = &quirk_acer_predator_ph315_52,
      },
      {
          .callback = dmi_matched,
@@ -2325,7 +2343,7 @@ enum acer_wmi_predator_v4_oc {
  {
      const int max_retries = 10;
      int delay_ms = 100;
-     if (!quirks->predator_v4 && !quirks->nitro_sense && !quirks->nitro_v4)
+     if (quirks->predator_v4 != 1 && quirks->nitro_sense != 1 && !quirks->nitro_v4)
          return 0;
      for (int attempt = 1; attempt <= max_retries; attempt++) {
          platform_profile_device = devm_platform_profile_register(


### PR DESCRIPTION
i added support for PH315-52 and tested it all function are working other than the thermal profiles i think that's unsupported by the hardware.

Added DMI quirk for Acer Predator PH315-52 and fix platform_profile guard.

The PH315-52 (2019 Helios 300) currently has no quirk entry. Without
one, predator_sense features (fan control, battery limiter, RGB
keyboard) and four_zoned_kb support are not available.

Add a dedicated quirk matched by DMI_BOARD_NAME QX50_CMS (the PH315-52
motherboard identifier). DMI_BOARD_NAME is used instead of
DMI_PRODUCT_NAME because some units with BIOS V2.04 incorrectly report
system-product-name as Predator PH315-53.

Additionally, fix the early-exit guard in acer_platform_profile_setup()
to check predator_v4 == 1 and nitro_sense == 1 explicitly instead of
using truthy checks. Previously, quirks with predator_v4 = 2 or
nitro_sense = 2 would incorrectly enter the platform_profile retry
loop.

Platform_profile registration fails gracefully on PredatorSense v3
firmware (methods 22/23 sub-functions 0xA/0xB return EIO) — the
existing retry-and-continue logic handles this correctly.

All other features work on PH315-52:
- Fan control via methods 14+16 (SET_GAMING_FAN_BEHAVIOR + FAN_SPEED)
- Battery health via methods 20/21
- RGB keyboard via methods 6/7/20/21

Tested on: PH315-52, i7-10750H, BIOS V2.04, CachyOS kernel 6.19.7.