### PR TITLE
enable predator_sense and four_zone_kb on PH315-53

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -436,9 +436,12 @@ enum acer_wmi_predator_v4_oc {
          }
 
  
-     if (quirks->predator_v4)
-         interface->capability |= ACER_CAP_PLATFORM_PROFILE |
-                      ACER_CAP_FAN_SPEED_READ | ACER_CAP_PREDATOR_SENSE;
+    if (quirks->predator_v4 == 1)
+                interface->capability |= ACER_CAP_PLATFORM_PROFILE |
+                ACER_CAP_FAN_SPEED_READ | ACER_CAP_PREDATOR_SENSE;
+                else if (quirks->predator_v4 == 2)
+                /* PredatorSense v3 firmware: thermal profile WMI methods not implemented */
+                interface->capability |= ACER_CAP_FAN_SPEED_READ | ACER_CAP_PREDATOR_SENSE;
      
      /* Includes all feature that predatorv4 have*/
      if (quirks->nitro_v4)
@@ -472,6 +475,12 @@ enum acer_wmi_predator_v4_oc {
      .mailled = 1,
  };
  
+ static struct quirk_entry quirk_acer_predator_ph315_52 = {
+     .turbo = 1,
+     .predator_v4 = 2,
+     .four_zone_kb = 1,
+ };
+
  static struct quirk_entry quirk_acer_predator_ph315_53 = {
      .turbo = 1,
      .cpu_fans = 1,
@@ -768,6 +777,15 @@ enum acer_wmi_predator_v4_oc {
              DMI_MATCH(DMI_PRODUCT_NAME, "TravelMate 4200"),
          },
          .driver_data = &quirk_acer_travelmate_2490,
+     },
+     {
+         .callback = dmi_matched,
+         .ident = "Acer Predator PH315-52",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_BOARD_NAME, "QX50_CMS"),
+         },
+         .driver_data = &quirk_acer_predator_ph315_52,
      },
      {
          .callback = dmi_matched,
@@ -2325,7 +2343,7 @@ enum acer_wmi_predator_v4_oc {
  {
      const int max_retries = 10;
      int delay_ms = 100;
-     if (!quirks->predator_v4 && !quirks->nitro_sense && !quirks->nitro_v4)
+     if (quirks->predator_v4 != 1 && quirks->nitro_sense != 1 && !quirks->nitro_v4)
          return 0;
      for (int attempt = 1; attempt <= max_retries; attempt++) {
          platform_profile_device = devm_platform_profile_register(

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -440,7 +440,7 @@ enum acer_wmi_predator_v4_oc {
                 interface->capability |= ACER_CAP_PLATFORM_PROFILE |
                 ACER_CAP_FAN_SPEED_READ | ACER_CAP_PREDATOR_SENSE;
                 else if (quirks->predator_v4 == 2)
-                /* PredatorSense v3 firmware: thermal profile WMI methods not implemented */
+                /* PredatorSense v3: platform_profile methods not present in firmware */
                 interface->capability |= ACER_CAP_FAN_SPEED_READ | ACER_CAP_PREDATOR_SENSE;
      
      /* Includes all feature that predatorv4 have*/
@@ -475,16 +475,12 @@ enum acer_wmi_predator_v4_oc {
      .mailled = 1,
  };
  
- static struct quirk_entry quirk_acer_predator_ph315_52 = {
-     .turbo = 1,
-     .predator_v4 = 2,
-     .four_zone_kb = 1,
- };
-
  static struct quirk_entry quirk_acer_predator_ph315_53 = {
      .turbo = 1,
      .cpu_fans = 1,
      .gpu_fans = 1,
+     .predator_v4 = 2,
+     .four_zone_kb = 1,
  };
  
  static struct quirk_entry quirk_acer_predator_phn16_71 = {
@@ -777,15 +773,6 @@ enum acer_wmi_predator_v4_oc {
              DMI_MATCH(DMI_PRODUCT_NAME, "TravelMate 4200"),
          },
          .driver_data = &quirk_acer_travelmate_2490,
-     },
-     {
-         .callback = dmi_matched,
-         .ident = "Acer Predator PH315-52",
-         .matches = {
-             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-             DMI_MATCH(DMI_BOARD_NAME, "QX50_CMS"),
-         },
-         .driver_data = &quirk_acer_predator_ph315_52,
      },
      {
          .callback = dmi_matched,


### PR DESCRIPTION
The PH315-53 quirk currently only sets .turbo, .cpu_fans, and .gpu_fans.
This leaves predator_sense features (fan speed control, battery limiter,
LCD override, etc.), four_zoned_kb (RGB effects and per-zone colors), and
hwmon fan RPM unavailable.

The PH315-53 runs PredatorSense v3 firmware, which supports these features
through the same WMI methods used by v4 devices, but does not implement
the platform_profile thermal mode methods (22/23 sub-functions 0xA/0xB).
Setting predator_v4 = 1 would work but wastes ~7 seconds on boot running
a 10-retry registration loop that can never succeed.

This patch:

1. Extends predator_v4 to support value 2, which enables predator_sense
   and fan speed capabilities without attempting platform_profile
   registration. This mirrors the existing nitro_sense == 2 convention.

2. Fixes the early-exit guard in acer_platform_profile_setup() to use
   explicit == 1 checks instead of truthy checks, so value-2 devices
   (and nitro_sense == 2) actually skip the retry loop.

3. Adds .predator_v4 = 2 and .four_zone_kb = 1 to the existing
   PH315-53 quirk.

Tested on PH315-53: fan control, battery limiter, RGB effects, per-zone
colors, hwmon, and turbo all work. Module loads with no platform_profile
retry warnings.