### PR TITLE
Add hardware quirk for Acer Predator PHIN16S-71 (BIOS Typo)

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -765,12 +765,12 @@ enum acer_wmi_predator_v4_oc {
          },
          .driver_data = &quirk_acer_predator_ph315_53,
      },
-     {
+    {
          .callback = dmi_matched,
-         .ident = "Acer Predator PHN16-71",
+         .ident = "Acer Predator PHIN16-71",
          .matches = {
              DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-             DMI_MATCH(DMI_PRODUCT_NAME, "Predator PHN16-71"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Predator PHIN16-71"),
          },
          .driver_data = &quirk_acer_predator_phn16_71,
      },
@@ -802,11 +802,20 @@ enum acer_wmi_predator_v4_oc {
         .driver_data = &quirk_acer_predator_phn16s_71,
      },
      {
+        .callback = dmi_matched,
+        .ident = "Acer Predator PHIN16S-71",
+        .matches = {
+            DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+            DMI_MATCH(DMI_PRODUCT_NAME, "Predator PHIN16S-71")
+        },
+        .driver_data = &quirk_acer_predator_phn16s_71,
+     },
+     {
          .callback = dmi_matched,
-         .ident = "Acer Predator PH16-71",
+         .ident = "Acer Predator PHN16S-71",
          .matches = {
              DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
-             DMI_MATCH(DMI_PRODUCT_NAME, "Predator PH16-71"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Predator PHN16S-71"),
          },
          .driver_data = &quirk_acer_predator_v4,
      },

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -482,6 +482,11 @@ enum acer_wmi_predator_v4_oc {
     .predator_v4 = 1,
     .four_zone_kb = 1,
  };
+
+ static struct quirk_entry quirk_acer_predator_phn16_73 = {
+    .predator_v4 = 1,
+    .four_zone_kb = 1,
+ };
  
  static struct quirk_entry quirk_acer_nitro_an16_41 = {
     .nitro_v4 = 1,
@@ -772,7 +777,16 @@ enum acer_wmi_predator_v4_oc {
             DMI_MATCH(DMI_PRODUCT_NAME, "Predator PHN16-72"),
         },
         .driver_data = &quirk_acer_predator_phn16_72,
-    },
+     },
+     {
+        .callback = dmi_matched,
+        .ident = "Acer Predator PHN16-73",
+        .matches = {
+            DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+            DMI_MATCH(DMI_PRODUCT_NAME, "Predator PHN16-73"),
+        },
+        .driver_data = &quirk_acer_predator_phn16_73,
+     },
      {
          .callback = dmi_matched,
          .ident = "Acer Predator PH16-71",

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -487,6 +487,11 @@ enum acer_wmi_predator_v4_oc {
     .predator_v4 = 1,
     .four_zone_kb = 1,
  };
+
+ static struct quirk_entry quirk_acer_predator_phn16s_71 = {
+    .predator_v4 = 1,
+    .four_zone_kb = 1,
+ };
  
  static struct quirk_entry quirk_acer_nitro_an16_41 = {
     .nitro_v4 = 1,
@@ -786,6 +791,15 @@ enum acer_wmi_predator_v4_oc {
             DMI_MATCH(DMI_PRODUCT_NAME, "Predator PHN16-73"),
         },
         .driver_data = &quirk_acer_predator_phn16_73,
+     },
+     {
+        .callback = dmi_matched,
+        .ident = "Acer Predator PHN16S-71",
+        .matches = {
+            DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+            DMI_MATCH(DMI_PRODUCT_NAME, "Predator PHN16S-71")
+        },
+        .driver_data = &quirk_acer_predator_phn16s_71,
      },
      {
          .callback = dmi_matched,


### PR DESCRIPTION
**Issue**: Some units of the Acer Predator PHN16S-71 have a typo in their BIOS DMI strings, returning `Predator PHIN16S-71` (with an "I"). Because the DMI match is strictly checking for `PHN`, the `linuwu-sense` driver fails to map the laptop to its corresponding hardware profile, causing the daemon to hang in a retry loop on boot.

**Solution**: Added a duplicate block to the `acer_quirks` array that strictly matches the `PHIN16S-71` string and points it to the existing `quirk_acer_predator_phn16s_71` profile. This allows the driver to initialize natively without needing to force parameters through the Internals Manager. Tested and confirmed working. 