### PR TITLE
Added Support for PH16-72

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -816,6 +816,15 @@ enum acer_wmi_predator_v4_oc {
      },
      {
          .callback = dmi_matched,
+         .ident = "Acer Predator PH16-72",
+         .matches = {
+             DMI_MATCH(DMI_SYS_VENDOR, "Acer"),
+             DMI_MATCH(DMI_PRODUCT_NAME, "Predator PH16-72"),
+         },
+         .driver_data = &quirk_acer_predator_v4,
+     },
+     {
+         .callback = dmi_matched,
          .ident = "Acer Predator PTX17-71",
          .matches = {
              DMI_MATCH(DMI_SYS_VENDOR, "Acer"),


### PR DESCRIPTION
feat: add support for Acer Predator PH16-72
- Added DMI string matching for "Predator PH16-72" in the `acer_quirks` table.
- Uses the existing predator_v4 quirk which works for the most part