### PR TITLE
Enable Predator Sense features for Predator PH315-53

### DIFF
--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -476,6 +476,7 @@ enum acer_wmi_predator_v4_oc {
      .turbo = 1,
      .cpu_fans = 1,
      .gpu_fans = 1,
+     .predator_v4 = 1,
  };
  
  static struct quirk_entry quirk_acer_predator_phn16_71 = {


### PR DESCRIPTION
Confirmed that the following Predator Sense features work:
- Backlight Timeout
- Battery Calibration
- Battery Limiter
- Boot Animation Sound
- Fan Speed
- USB Charging

Tested on system with these specs:
OS: Pop!_OS 24.04 LTS
Host: Predator PH315-53 
Kernel: 6.18.7-76061807-generic 
CPU: Intel i5-10300H (8) @ 4.500GHz
GPU: NVIDIA GeForce RTX 2060 Mobile