### PR TITLE
Fix build failure on kernels where strncpy is undeclared (e.g. 7.2.0+)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+*.o
+*.o.cmd
+*.ko
+*.ko.cmd
+*.mod
+*.mod.c
+*.mod.o
+*.mod.o.cmd
+*.symvers
+*.symvers.cmd
+modules.order
+modules.order.cmd

--- a/src/linuwu_sense.c
+++ b/src/linuwu_sense.c
@@ -14,6 +14,7 @@
  #include <linux/delay.h>
  #include <linux/kernel.h>
  #include <linux/module.h>
+#include <linux/string.h>
  #include <linux/init.h>
  #include <linux/types.h>
  #include <linux/dmi.h>
@@ -3299,7 +3300,7 @@ enum acer_wmi_predator_v4_oc {
      char *token;
      char* input_ptr = input;
      size_t len = min(count, sizeof(input) - 1);
-     strncpy(input, buf, len);
+     memcpy(input, buf, len);
  
      if(input[len-1] == '\n'){
          input[len-1] = '\0';
@@ -3750,7 +3751,7 @@ enum acer_wmi_predator_v4_oc {
      char *input_ptr = input_buf;
      size_t len = min(count, sizeof(input_buf) - 1);
  
-     strncpy(input_buf, buf, len);
+     memcpy(input_buf, buf, len);
  
      if(input_buf[len-1] == '\n'){
          input_buf[len-1] = '\0';
@@ -3923,7 +3924,7 @@ enum acer_wmi_predator_v4_oc {
      struct per_zone_color colors;
      char *input_ptr = str_buf;
      len = min(count, sizeof(str_buf) - 1);
-     strncpy(str_buf, buf, len);
+     memcpy(str_buf, buf, len);
      if(str_buf[len-1] == '\n'){
          str_buf[len-1] = '\0';
      } else {


### PR DESCRIPTION
Newer kernel headers (tested on 7.2.0-1-cachyos) no longer declare `strncpy`
in linux/string.h, causing a build failure:

    error: call to undeclared library function 'strncpy'

This replaces the 3 strncpy() calls in linuwu_sense.c with memcpy(), since
in each case the destination buffer is already manually null-terminated
right after the copy, making memcpy a safe drop-in replacement.

Also added a .gitignore for build artifacts (*.o, *.ko, etc.) that were
previously untracked and cluttering `git status`.